### PR TITLE
Revert release script fixes from main

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,6 @@
 - Clean up gemspec metadata for release builds.
 - Replace the stale release script with the current Bundler/RubyGems release flow and document it.
 - Create the GitHub release from `script/release` using the matching `CHANGES.md` notes.
-- Make `script/release` fail earlier on missing RubyGems credentials and resume GitHub release creation when the release tag already exists.
-- Make `script/release` fail early when macOS system Ruby is active and document running releases through mise.
-- Make `script/release` automatically re-run through mise when the active shell is using the wrong Ruby.
 
 ## v3.0.0
 - Add Github Actions CI

--- a/README.md
+++ b/README.md
@@ -422,13 +422,10 @@ Releases use Bundler's gem release task. Prepare the version bump and `CHANGES.m
 git switch main
 git pull origin main
 gem signin
-gh auth login
 script/release
 ```
 
-The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. If the active shell is using the wrong Ruby and `mise` is installed, the script automatically re-runs itself through the Ruby configured in `mise.toml`. The Bundler release task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
-
-If the gem/tag publish succeeds but GitHub release creation fails, rerun `script/release`. The script will reuse the existing tag and finish creating the GitHub release.
+The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. That Bundler task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
 
 To check the release flow without publishing:
 

--- a/script/release
+++ b/script/release
@@ -10,74 +10,6 @@ current_version() {
   ruby ./lib/jmeter-ruby/version.rb
 }
 
-run_with_mise_if_available() {
-  if [ "${JMETER_RUBY_RELEASE_MISE:-}" = "1" ]; then
-    return 1
-  fi
-
-  if ! command -v mise > /dev/null; then
-    return 1
-  fi
-
-  echo "Active Ruby is not supported. Re-running release with mise."
-  mise trust
-  mise install
-  JMETER_RUBY_RELEASE_MISE=1 exec mise exec -- "$0" "$@"
-}
-
-required_ruby_version() {
-  ruby -e 'spec = Gem::Specification.load("jmeter-ruby.gemspec"); puts spec.required_ruby_version.requirements.first.last'
-}
-
-current_ruby_version() {
-  ruby -e 'puts RUBY_VERSION'
-}
-
-require_supported_ruby() {
-  local required_version
-  local active_version
-
-  required_version="$(required_ruby_version)"
-  active_version="$(current_ruby_version)"
-
-  if ruby -e "exit(Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('$required_version'))"; then
-    return
-  fi
-
-  run_with_mise_if_available "$@"
-
-  echo "Error: Ruby ${required_version} or newer is required, but active ruby is ${active_version}."
-  echo "Active ruby: $(command -v ruby)"
-  echo "Install/activate the project Ruby first, for example:"
-  echo "  mise trust && mise install"
-  echo "Then rerun:"
-  echo "  script/release"
-  exit 1
-}
-
-require_bundler() {
-  if command -v bundle > /dev/null && bundle -v > /dev/null 2>&1; then
-    return
-  fi
-
-  echo "Error: Bundler is not available for the active Ruby."
-  echo "Active ruby: $(command -v ruby)"
-  if [ -f Gemfile.lock ]; then
-    local bundled_version
-    bundled_version="$(awk '/^BUNDLED WITH$/ { getline; gsub(/^[[:space:]]+/, ""); print; exit }' Gemfile.lock)"
-
-    if [ -n "$bundled_version" ]; then
-      echo "Install the locked Bundler for this Ruby with:"
-      echo "  gem install bundler:${bundled_version}"
-      exit 1
-    fi
-  fi
-
-  echo "Install Bundler for this Ruby with:"
-  echo "  gem install bundler"
-  exit 1
-}
-
 working_tree_is_clean() {
   [ -z "$(git status --porcelain)" ]
 }
@@ -117,23 +49,6 @@ require_github_cli() {
   fi
 }
 
-require_rubygems_credentials() {
-  if gem owner jmeter-ruby > /dev/null 2>&1; then
-    return
-  fi
-
-  if [ -t 0 ]; then
-    echo "RubyGems credentials are missing or invalid. Starting gem signin."
-    gem signin
-  fi
-
-  if ! gem owner jmeter-ruby > /dev/null 2>&1; then
-    echo "Error: RubyGems credentials are missing, invalid, or cannot access jmeter-ruby."
-    echo "Run gem signin, make sure you are an owner of jmeter-ruby, then rerun script/release."
-    exit 1
-  fi
-}
-
 write_release_notes() {
   local version="$1"
   local notes_file="$2"
@@ -163,23 +78,8 @@ create_github_release() {
     --notes-file "$notes_file"
 }
 
-release_tag_and_gem() {
-  local version="$1"
-
-  if tag_exists "$version"; then
-    echo "Tag v${version} already exists. Skipping gem publish and tag creation."
-    return
-  fi
-
-  bundle exec rake release
-}
-
 main() {
   local version
-
-  require_supported_ruby "$@"
-  require_bundler
-
   version="$(current_version)"
 
   echo "Preparing to release jmeter-ruby ${version}"
@@ -206,8 +106,12 @@ main() {
     exit 1
   fi
 
+  if tag_exists "$version"; then
+    echo "Error: tag v${version} already exists."
+    exit 1
+  fi
+
   require_github_cli
-  require_rubygems_credentials
 
   if github_release_exists "$version"; then
     echo "Error: GitHub release v${version} already exists."
@@ -223,7 +127,7 @@ main() {
     exit 0
   fi
 
-  release_tag_and_gem "$version"
+  bundle exec rake release
   create_github_release "$version"
 
   echo "Released jmeter-ruby ${version}."


### PR DESCRIPTION
## Summary

- Revert the release-script follow-up commits that were pushed directly to `main` after merge commit `92fc019`.
- This restores `main` content to the state from PR #12 while preserving the follow-up work on the `release-script-fixes` branch.

## Context

The protected `main` branch rejects force-pushes, so the direct commits cannot be removed from history by rewriting `main`. This PR removes their content through a normal protected-branch workflow.

Moved commits preserved on branch `release-script-fixes`:

- `d15cb98` Make release script resumable
- `bb182e9` Check Ruby before release
- `9a3acdb` Auto-run release script with mise

## Validation

- `bundle exec rake spec` - 164 examples, 0 failures