### PR TITLE
Fix release script workflow

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Create the GitHub release from `script/release` using the matching `CHANGES.md` notes.
 - Make `script/release` fail earlier on missing RubyGems credentials and resume GitHub release creation when the release tag already exists.
 - Make `script/release` fail early when macOS system Ruby is active and document running releases through mise.
+- Make `script/release` automatically re-run through mise when the active shell is using the wrong Ruby.
 
 ## v3.0.0
 - Add Github Actions CI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 - Replace the stale release script with the current Bundler/RubyGems release flow and document it.
 - Create the GitHub release from `script/release` using the matching `CHANGES.md` notes.
 - Make `script/release` fail earlier on missing RubyGems credentials and resume GitHub release creation when the release tag already exists.
+- Make `script/release` fail early when macOS system Ruby is active and document running releases through mise.
 
 ## v3.0.0
 - Add Github Actions CI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@
 - Clean up gemspec metadata for release builds.
 - Replace the stale release script with the current Bundler/RubyGems release flow and document it.
 - Create the GitHub release from `script/release` using the matching `CHANGES.md` notes.
+- Make `script/release` fail earlier on missing RubyGems credentials and resume GitHub release creation when the release tag already exists.
 
 ## v3.0.0
 - Add Github Actions CI

--- a/README.md
+++ b/README.md
@@ -421,21 +421,19 @@ Releases use Bundler's gem release task. Prepare the version bump and `CHANGES.m
 ```sh
 git switch main
 git pull origin main
-mise trust
-mise install
-mise exec -- gem signin
+gem signin
 gh auth login
-mise exec -- script/release
+script/release
 ```
 
-The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. That Bundler task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
+The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. If the active shell is using the wrong Ruby and `mise` is installed, the script automatically re-runs itself through the Ruby configured in `mise.toml`. The Bundler release task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
 
 If the gem/tag publish succeeds but GitHub release creation fails, rerun `script/release`. The script will reuse the existing tag and finish creating the GitHub release.
 
 To check the release flow without publishing:
 
 ```sh
-DRY_RUN=1 mise exec -- script/release
+DRY_RUN=1 script/release
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -421,8 +421,11 @@ Releases use Bundler's gem release task. Prepare the version bump and `CHANGES.m
 ```sh
 git switch main
 git pull origin main
-gem signin
-script/release
+mise trust
+mise install
+mise exec -- gem signin
+gh auth login
+mise exec -- script/release
 ```
 
 The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. That Bundler task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
@@ -432,7 +435,7 @@ If the gem/tag publish succeeds but GitHub release creation fails, rerun `script
 To check the release flow without publishing:
 
 ```sh
-DRY_RUN=1 script/release
+DRY_RUN=1 mise exec -- script/release
 ```
 
 ### Examples

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ script/release
 
 The release script verifies that `main` is clean and synced, runs `bundle install`, runs the specs, builds the gem, and then delegates publishing to `bundle exec rake release`. That Bundler task creates and pushes the `vX.Y.Z` git tag and pushes the gem to RubyGems.org. After that, the script creates the GitHub release for the same tag using the matching `CHANGES.md` section.
 
+If the gem/tag publish succeeds but GitHub release creation fails, rerun `script/release`. The script will reuse the existing tag and finish creating the GitHub release.
+
 To check the release flow without publishing:
 
 ```sh

--- a/script/release
+++ b/script/release
@@ -10,6 +10,56 @@ current_version() {
   ruby ./lib/jmeter-ruby/version.rb
 }
 
+required_ruby_version() {
+  ruby -e 'spec = Gem::Specification.load("jmeter-ruby.gemspec"); puts spec.required_ruby_version.requirements.first.last'
+}
+
+current_ruby_version() {
+  ruby -e 'puts RUBY_VERSION'
+}
+
+require_supported_ruby() {
+  local required_version
+  local active_version
+
+  required_version="$(required_ruby_version)"
+  active_version="$(current_ruby_version)"
+
+  if ruby -e "exit(Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('$required_version'))"; then
+    return
+  fi
+
+  echo "Error: Ruby ${required_version} or newer is required, but active ruby is ${active_version}."
+  echo "Active ruby: $(command -v ruby)"
+  echo "Install/activate the project Ruby first, for example:"
+  echo "  mise trust && mise install"
+  echo "  mise exec -- script/release"
+  exit 1
+}
+
+require_bundler() {
+  if command -v bundle > /dev/null && bundle -v > /dev/null 2>&1; then
+    return
+  fi
+
+  echo "Error: Bundler is not available for the active Ruby."
+  echo "Active ruby: $(command -v ruby)"
+  if [ -f Gemfile.lock ]; then
+    local bundled_version
+    bundled_version="$(awk '/^BUNDLED WITH$/ { getline; gsub(/^[[:space:]]+/, ""); print; exit }' Gemfile.lock)"
+
+    if [ -n "$bundled_version" ]; then
+      echo "Install the locked Bundler for this Ruby with:"
+      echo "  gem install bundler:${bundled_version}"
+      exit 1
+    fi
+  fi
+
+  echo "Install Bundler for this Ruby with:"
+  echo "  gem install bundler"
+  exit 1
+}
+
 working_tree_is_clean() {
   [ -z "$(git status --porcelain)" ]
 }
@@ -108,6 +158,10 @@ release_tag_and_gem() {
 
 main() {
   local version
+
+  require_supported_ruby
+  require_bundler
+
   version="$(current_version)"
 
   echo "Preparing to release jmeter-ruby ${version}"

--- a/script/release
+++ b/script/release
@@ -10,6 +10,21 @@ current_version() {
   ruby ./lib/jmeter-ruby/version.rb
 }
 
+run_with_mise_if_available() {
+  if [ "${JMETER_RUBY_RELEASE_MISE:-}" = "1" ]; then
+    return 1
+  fi
+
+  if ! command -v mise > /dev/null; then
+    return 1
+  fi
+
+  echo "Active Ruby is not supported. Re-running release with mise."
+  mise trust
+  mise install
+  JMETER_RUBY_RELEASE_MISE=1 exec mise exec -- "$0" "$@"
+}
+
 required_ruby_version() {
   ruby -e 'spec = Gem::Specification.load("jmeter-ruby.gemspec"); puts spec.required_ruby_version.requirements.first.last'
 }
@@ -29,11 +44,14 @@ require_supported_ruby() {
     return
   fi
 
+  run_with_mise_if_available "$@"
+
   echo "Error: Ruby ${required_version} or newer is required, but active ruby is ${active_version}."
   echo "Active ruby: $(command -v ruby)"
   echo "Install/activate the project Ruby first, for example:"
   echo "  mise trust && mise install"
-  echo "  mise exec -- script/release"
+  echo "Then rerun:"
+  echo "  script/release"
   exit 1
 }
 
@@ -159,7 +177,7 @@ release_tag_and_gem() {
 main() {
   local version
 
-  require_supported_ruby
+  require_supported_ruby "$@"
   require_bundler
 
   version="$(current_version)"

--- a/script/release
+++ b/script/release
@@ -49,6 +49,23 @@ require_github_cli() {
   fi
 }
 
+require_rubygems_credentials() {
+  if gem owner jmeter-ruby > /dev/null 2>&1; then
+    return
+  fi
+
+  if [ -t 0 ]; then
+    echo "RubyGems credentials are missing or invalid. Starting gem signin."
+    gem signin
+  fi
+
+  if ! gem owner jmeter-ruby > /dev/null 2>&1; then
+    echo "Error: RubyGems credentials are missing, invalid, or cannot access jmeter-ruby."
+    echo "Run gem signin, make sure you are an owner of jmeter-ruby, then rerun script/release."
+    exit 1
+  fi
+}
+
 write_release_notes() {
   local version="$1"
   local notes_file="$2"
@@ -76,6 +93,17 @@ create_github_release() {
   gh release create "v${version}" \
     --title "v${version}" \
     --notes-file "$notes_file"
+}
+
+release_tag_and_gem() {
+  local version="$1"
+
+  if tag_exists "$version"; then
+    echo "Tag v${version} already exists. Skipping gem publish and tag creation."
+    return
+  fi
+
+  bundle exec rake release
 }
 
 main() {
@@ -106,12 +134,8 @@ main() {
     exit 1
   fi
 
-  if tag_exists "$version"; then
-    echo "Error: tag v${version} already exists."
-    exit 1
-  fi
-
   require_github_cli
+  require_rubygems_credentials
 
   if github_release_exists "$version"; then
     echo "Error: GitHub release v${version} already exists."
@@ -127,7 +151,7 @@ main() {
     exit 0
   fi
 
-  bundle exec rake release
+  release_tag_and_gem "$version"
   create_github_release "$version"
 
   echo "Released jmeter-ruby ${version}."


### PR DESCRIPTION
## Summary

- Make `script/release` resumable when the gem/tag publish succeeds but GitHub Release creation fails.
- Add early RubyGems credential checks so release failures are clearer.
- Add Ruby and Bundler preflight checks before invoking Bundler tasks.
- Automatically re-run `script/release` through mise when the active shell is using an unsupported Ruby, so users can still run `script/release` normally.
- Update release docs and v3.0.1 changelog notes for the fixed workflow.

## Context

These changes were moved off `main` after PR #13 restored the branch content. This PR now carries the release-script follow-up work through the normal review path.

## Validation

- `bundle exec rake spec` - 164 examples, 0 failures